### PR TITLE
Added ability to add section to binary.

### DIFF
--- a/portable_executable/main.cpp
+++ b/portable_executable/main.cpp
@@ -53,8 +53,10 @@ std::int32_t main()
 
 	FreeLibrary(user32);
 
+	std::string_view ntoskrnl_path_view = "C:\\Windows\\System32\\ntoskrnl.exe";
+
 	// load a portable executable from filesystem
-	portable_executable::file_t ntoskrnl("C:\\Windows\\System32\\ntoskrnl.exe");
+	portable_executable::file_t ntoskrnl(ntoskrnl_path_view);
 
 	// avoid exceptions in constructor to support contexts without exception support
 	if (!ntoskrnl.load())

--- a/portable_executable/portable_executable/image.hpp
+++ b/portable_executable/portable_executable/image.hpp
@@ -8,6 +8,8 @@
 #include "imports_directory.hpp"
 #include "relocations_directory.hpp"
 
+#include <vector>
+
 namespace portable_executable
 {
 	class image_t
@@ -37,6 +39,58 @@ namespace portable_executable
 		[[nodiscard]] section_iterator_t<const section_header_t> sections() const
 		{
 			return { this->nt_headers()->section_headers(), this->nt_headers()->num_sections() };
+		}
+
+		template <class t>
+		t calculate_alignment(t address, t alignment)
+		{
+			return address + (alignment - (address % alignment));
+		}
+
+		std::vector<std::uint8_t> add_section(std::string_view name, std::uint32_t size, std::uint32_t characteristics)
+		{
+			if (8 < name.size())
+			{
+				return { };
+			}
+
+			const portable_executable::nt_headers_t* nt_headers = this->nt_headers();
+
+			const portable_executable::section_header_t* section_header = this->nt_headers()->section_headers();
+
+			const portable_executable::section_header_t* last_section_header = &section_header[nt_headers->num_sections() - 1];
+
+			portable_executable::section_header_t* new_section_header = reinterpret_cast<portable_executable::section_header_t*>(reinterpret_cast<std::uint64_t>(&last_section_header->characteristics) + 4);
+
+			memcpy(new_section_header, name.data(), name.size());
+
+			new_section_header->virtual_address = calculate_alignment(last_section_header->virtual_address + last_section_header->virtual_size, nt_headers->optional_header.section_alignment);
+			new_section_header->virtual_size = calculate_alignment(size + 5, nt_headers->optional_header.section_alignment);
+			new_section_header->pointer_to_raw_data = calculate_alignment(last_section_header->pointer_to_raw_data + last_section_header->size_of_raw_data, nt_headers->optional_header.file_alignment);
+			new_section_header->size_of_raw_data = calculate_alignment(size + 5, nt_headers->optional_header.file_alignment);
+			new_section_header->characteristics = { .flags = characteristics };
+
+			new_section_header->pointer_to_linenumbers = 0;
+			new_section_header->pointer_to_relocations = 0;
+			new_section_header->number_of_linenumbers = 0;
+			new_section_header->number_of_relocations = 0;
+
+			std::vector<std::uint8_t> binary_snapshot = { this->as<const std::uint8_t*>(), this->as<const std::uint8_t*>() + nt_headers->optional_header.size_of_image };
+
+			image_t* new_image = reinterpret_cast<image_t*>(binary_snapshot.data());
+
+			for (portable_executable::section_header_t& section : new_image->sections())
+			{
+				section.pointer_to_raw_data = section.virtual_address;
+			}
+
+			new_image->nt_headers()->optional_header.size_of_image = calculate_alignment(new_image->nt_headers()->optional_header.size_of_image + size + 5 + static_cast<std::uint32_t>(sizeof(portable_executable::section_header_t)), nt_headers->optional_header.section_alignment);
+			new_image->nt_headers()->optional_header.size_of_headers = calculate_alignment(new_image->nt_headers()->optional_header.size_of_headers + static_cast<std::uint32_t>(sizeof(portable_executable::section_header_t)), nt_headers->optional_header.file_alignment);
+			new_image->nt_headers()->file_header.number_of_sections++;
+
+			binary_snapshot.resize(new_image->nt_headers()->optional_header.size_of_image);
+
+			return binary_snapshot;
 		}
 
 		exports_range_t<exports_iterator_t> exports()

--- a/portable_executable/portable_executable/image.hpp
+++ b/portable_executable/portable_executable/image.hpp
@@ -47,7 +47,7 @@ namespace portable_executable
 			return address + (alignment - (address % alignment));
 		}
 
-		std::vector<std::uint8_t> add_section(std::string_view name, std::uint32_t size, std::uint32_t characteristics)
+		std::vector<std::uint8_t> add_section(std::string_view name, std::uint32_t size, std::uint32_t characteristics, bool is_image_decompressed = false)
 		{
 			if (8 < name.size())
 			{
@@ -66,8 +66,8 @@ namespace portable_executable
 
 			new_section_header->virtual_address = calculate_alignment(last_section_header->virtual_address + last_section_header->virtual_size, nt_headers->optional_header.section_alignment);
 			new_section_header->virtual_size = calculate_alignment(size + 5, nt_headers->optional_header.section_alignment);
-			new_section_header->pointer_to_raw_data = calculate_alignment(last_section_header->pointer_to_raw_data + last_section_header->size_of_raw_data, nt_headers->optional_header.file_alignment);
-			new_section_header->size_of_raw_data = calculate_alignment(size + 5, nt_headers->optional_header.file_alignment);
+			new_section_header->pointer_to_raw_data = is_image_decompressed ? new_section_header->virtual_address : calculate_alignment(last_section_header->pointer_to_raw_data + last_section_header->size_of_raw_data, nt_headers->optional_header.file_alignment);
+			new_section_header->size_of_raw_data = is_image_decompressed ? new_section_header->virtual_size : calculate_alignment(size + 5, nt_headers->optional_header.file_alignment);
 			new_section_header->characteristics = { .flags = characteristics };
 
 			new_section_header->pointer_to_linenumbers = 0;


### PR DESCRIPTION
Added ability to add section to binary. This is accessible via image_t::add_section, and will append a section to the binary and return a buffer containing the whole binary (including the new section). The section is not applied to the runtime image, only returned in a buffer from the function.