### PR TITLE
Added debug directory parsing, fixed alignment calculation bug, and section name edge case

### DIFF
--- a/portable_executable/main.cpp
+++ b/portable_executable/main.cpp
@@ -31,7 +31,14 @@ static void run_image_tests(const portable_executable::image_t* image)
 
 	for (const auto [relocation_block, relocation_block_va] : image->relocations())
 	{
-		std::printf("offset: %x -> type: %x\n", relocation_block.offset, relocation_block.type);
+		std::printf("offset: 0x%x -> type: 0x%x\n", relocation_block.offset, relocation_block.type);
+	}
+
+	std::printf("iterating debug information...\n");
+
+	for (const auto debug_info : image->debug_info())
+	{
+		std::printf("va: 0x%x -> type: 0x%x\n", debug_info.virtual_address, static_cast<std::uint32_t>(debug_info.type));
 	}
 }
 

--- a/portable_executable/portable_executable.vcxproj
+++ b/portable_executable/portable_executable.vcxproj
@@ -99,6 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="portable_executable\data_directory.hpp" />
+    <ClInclude Include="portable_executable\debug_directory.hpp" />
     <ClInclude Include="portable_executable\dos_header.hpp" />
     <ClInclude Include="portable_executable\export_directory.hpp" />
     <ClInclude Include="portable_executable\file.hpp" />

--- a/portable_executable/portable_executable.vcxproj.filters
+++ b/portable_executable/portable_executable.vcxproj.filters
@@ -80,5 +80,8 @@
     <ClInclude Include="portable_executable\file.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="portable_executable\debug_directory.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/portable_executable/portable_executable/debug_directory.hpp
+++ b/portable_executable/portable_executable/debug_directory.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace portable_executable
+{
+    enum class debug_directory_type_t : std::uint32_t
+    {
+        unknown,
+        coff,
+        codeview,
+        fpo,
+        misc,
+        exception,
+        fixup,
+        omap_to_src,
+        omap_from_src,
+        borland,
+        _reserved0,
+        clsid,
+        vc_feature,
+        pogo,
+        iltcg,
+        mpx,
+        repro,
+        _undefined1,
+        _reserved1,
+        _undefined2,
+        ex_dll_characteristics
+    };
+
+    struct debug_directory_t
+    {
+        std::uint32_t characteristics;
+        std::uint32_t time_date_stamp;
+        std::uint16_t major_version;
+        std::uint16_t minor_version;
+        debug_directory_type_t type;
+        std::uint32_t size_of_data;
+        std::uint32_t virtual_address;
+        std::uint32_t pointer_to_raw_data;
+    };
+
+    template <typename T>
+    class debug_info_iterator_t
+    {
+    private:
+        using pointer_type = std::conditional_t<std::is_const_v<T>, const std::uint8_t*, std::uint8_t*>;
+        using const_pointer_type = const std::uint8_t*;
+
+        T* m_debug_info = nullptr;
+        T* m_end_debug_info = nullptr;
+
+    public:
+        debug_info_iterator_t() = default;
+
+        debug_info_iterator_t(const pointer_type module, const std::uint32_t debug_directory_rva, const std::uint32_t entry_count) :
+    		m_debug_info(reinterpret_cast<T*>(module + debug_directory_rva)),
+            m_end_debug_info(m_debug_info + entry_count)
+        {
+
+        }
+
+        [[nodiscard]] T* begin() const
+        {
+            return m_debug_info;
+        }
+
+        [[nodiscard]] T* end() const
+        {
+            return m_end_debug_info;
+        }
+    };
+}

--- a/portable_executable/portable_executable/image.hpp
+++ b/portable_executable/portable_executable/image.hpp
@@ -44,7 +44,14 @@ namespace portable_executable
 		template <class t>
 		t calculate_alignment(t address, t alignment)
 		{
-			return address + (alignment - (address % alignment));
+			const t remainder = address % alignment;
+
+			if (!remainder)
+			{
+				return address;
+			}
+
+			return address + (alignment - remainder);
 		}
 
 		std::vector<std::uint8_t> add_section(std::string_view name, std::uint32_t size, std::uint32_t characteristics, bool is_image_decompressed = false)

--- a/portable_executable/portable_executable/image.hpp
+++ b/portable_executable/portable_executable/image.hpp
@@ -10,6 +10,8 @@
 
 #include <vector>
 
+#include "debug_directory.hpp"
+
 namespace portable_executable
 {
 	class image_t
@@ -194,6 +196,38 @@ namespace portable_executable
 			auto module = reinterpret_cast<const std::uint8_t*>(this);
 
 			return { module, data_directory.virtual_address };
+		}
+
+		[[nodiscard]] debug_info_iterator_t<debug_directory_t> debug_info()
+		{
+			data_directory_t data_directory = this->nt_headers()->optional_header.data_directories.debug_directory;
+
+			if (!data_directory.present())
+			{
+				return { };
+			}
+
+			auto module = reinterpret_cast<std::uint8_t*>(this);
+
+			const std::uint32_t entries = data_directory.size / sizeof(debug_directory_t);
+
+			return { module, data_directory.virtual_address, entries };
+		}
+
+		[[nodiscard]] debug_info_iterator_t<const debug_directory_t> debug_info() const
+		{
+			data_directory_t data_directory = this->nt_headers()->optional_header.data_directories.debug_directory;
+
+			if (!data_directory.present())
+			{
+				return { };
+			}
+
+			auto module = reinterpret_cast<const std::uint8_t*>(this);
+
+			const std::uint32_t entries = data_directory.size / sizeof(debug_directory_t);
+
+			return { module, data_directory.virtual_address, entries };
 		}
 
 		section_header_t* find_section(std::string_view name);

--- a/portable_executable/portable_executable/section_header.cpp
+++ b/portable_executable/portable_executable/section_header.cpp
@@ -2,5 +2,5 @@
 
 std::string portable_executable::section_header_t::to_str() const
 {
-	return this->name;
+	return { this->name, this->name + sizeof(this->name) };
 }


### PR DESCRIPTION
Debug information is now parsed from the PE and able to be iterated.

The alignment would always round up even if already aligned. Now this is fixed with proper calculation.

If the section name used up all the space it is allocated, it wouldn't be null terminated. Now the string is constructed with a set range so it does not search for a null terminator.