### PR TITLE
Added exceptions parsing + updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ for (const auto& relocation : image->relocations())
 }
 ```
 
+### Iterating debug information
+The debug information iterator provides the caller with a raw view of the debug information.
+
+```cpp
+for (const auto debug_info : image->debug_info())
+{
+	std::printf("va: 0x%x -> type: 0x%x\n", debug_info.virtual_address, static_cast<std::uint32_t>(debug_info.type));
+}
+```
+
+### Iterating exceptions/runtime functions
+The runtime functions iterator abstracts away boilerplate code and returns the pointer to the function begin, function end, and the unwind info.
+
+The unwind code iterator provides the caller with a raw view of the unwind code. This is accessed via the unwind_info_t structure.
+
+```cpp
+for (const auto runtime_function : image->runtime_functions())
+{
+	const auto virtual_address = static_cast<std::uint32_t>(runtime_function.function_begin - image->as<const std::uint8_t*>());
+
+	std::printf("va: 0x%x -> unwind code count: 0x%x\n", virtual_address, runtime_function.unwind_info->unwind_code_count);
+
+	for (const auto unwind_opcode : *runtime_function.unwind_info)
+	{
+		std::printf("(unwind code) offset: 0x%x, info: 0x%x\n", unwind_opcode.offset, unwind_opcode.info);
+	}
+}
+```
+
 ### Signature scanning
 
 This library supports both IDA and Byte signature scanning.
@@ -80,6 +109,6 @@ std::printf("ntoskrnl!HviIsAnyHypervisorPresent -> 0x%p\n", hvi_is_any_hyperviso
 ```
 
 ## Credits
-- [noahswtf](https://github.com/noahswtf) for the relocations parsing functionality (iterator, definitions) via [this](https://github.com/papstuc/portable_executable/pull/1) pull request
+- [noahware](https://github.com/noahware) for the relocations parsing, debug information parsing, and exceptions parsing
 - [can1357](https://github.com/can1357) for section_characteristics_t, thunk_data_t, data_directory_t and data_directories_t definitions from his [linux-pe](https://github.com/can1357/linux-pe) library
 - [john](https://github.com/vmp38) for forcing me into releasing a version without any CRT linkage

--- a/portable_executable/main.cpp
+++ b/portable_executable/main.cpp
@@ -40,6 +40,20 @@ static void run_image_tests(const portable_executable::image_t* image)
 	{
 		std::printf("va: 0x%x -> type: 0x%x\n", debug_info.virtual_address, static_cast<std::uint32_t>(debug_info.type));
 	}
+
+	std::printf("iterating exceptions...\n");
+
+	for (const auto runtime_function : image->runtime_functions())
+	{
+		const auto virtual_address = static_cast<std::uint32_t>(runtime_function.function_begin - image->as<const std::uint8_t*>());
+
+		std::printf("va: 0x%x -> unwind code count: 0x%x\n", virtual_address, runtime_function.unwind_info->unwind_code_count);
+
+		for (const auto unwind_opcode : *runtime_function.unwind_info)
+		{
+			std::printf("(unwind code) offset: 0x%x, info: 0x%x\n", unwind_opcode.offset, unwind_opcode.info);
+		}
+	}
 }
 
 std::int32_t main()

--- a/portable_executable/portable_executable.vcxproj
+++ b/portable_executable/portable_executable.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="portable_executable\data_directory.cpp" />
     <ClCompile Include="portable_executable\dos_header.cpp" />
+    <ClCompile Include="portable_executable\exception_directory.cpp" />
     <ClCompile Include="portable_executable\export_directory.cpp" />
     <ClCompile Include="portable_executable\file.cpp" />
     <ClCompile Include="portable_executable\image.cpp" />
@@ -101,6 +102,7 @@
     <ClInclude Include="portable_executable\data_directory.hpp" />
     <ClInclude Include="portable_executable\debug_directory.hpp" />
     <ClInclude Include="portable_executable\dos_header.hpp" />
+    <ClInclude Include="portable_executable\exception_directory.hpp" />
     <ClInclude Include="portable_executable\export_directory.hpp" />
     <ClInclude Include="portable_executable\file.hpp" />
     <ClInclude Include="portable_executable\file_header.hpp" />

--- a/portable_executable/portable_executable.vcxproj.filters
+++ b/portable_executable/portable_executable.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="portable_executable\file.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="portable_executable\exception_directory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="portable_executable\dos_header.hpp">
@@ -81,6 +84,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="portable_executable\debug_directory.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="portable_executable\exception_directory.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/portable_executable/portable_executable/debug_directory.hpp
+++ b/portable_executable/portable_executable/debug_directory.hpp
@@ -47,7 +47,6 @@ namespace portable_executable
     {
     private:
         using pointer_type = std::conditional_t<std::is_const_v<T>, const std::uint8_t*, std::uint8_t*>;
-        using const_pointer_type = const std::uint8_t*;
 
         T* m_debug_info = nullptr;
         T* m_end_debug_info = nullptr;

--- a/portable_executable/portable_executable/exception_directory.cpp
+++ b/portable_executable/portable_executable/exception_directory.cpp
@@ -1,0 +1,59 @@
+#include "exception_directory.hpp"
+
+portable_executable::unwind_code_iterator_t portable_executable::unwind_info_t::begin() const
+{
+	return unwind_code_iterator_t{ codes };
+}
+
+portable_executable::unwind_code_iterator_t portable_executable::unwind_info_t::end() const
+{
+	return unwind_code_iterator_t{ codes + unwind_code_count };
+}
+
+portable_executable::unwind_code_iterator_t::value_type portable_executable::unwind_code_iterator_t::operator*() const
+{
+	return *m_current_code;
+}
+
+portable_executable::unwind_code_iterator_t& portable_executable::unwind_code_iterator_t::operator++()
+{
+	++m_current_code;
+
+	return *this;
+}
+
+bool portable_executable::unwind_code_iterator_t::operator==(const unwind_code_iterator_t& other) const
+{
+	return m_current_code == other.m_current_code;
+}
+
+bool portable_executable::unwind_code_iterator_t::operator!=(const unwind_code_iterator_t& other) const
+{
+	return m_current_code != other.m_current_code;
+}
+
+portable_executable::runtime_functions_iterator_t::value_type portable_executable::runtime_functions_iterator_t::operator*() const
+{
+	const auto function_begin = const_cast<std::uint8_t*>(m_module + m_current_function->begin_address);
+	const auto function_end = const_cast<std::uint8_t*>(m_module + m_current_function->end_address);
+	const auto unwind_info = reinterpret_cast<unwind_info_t*>(const_cast<std::uint8_t*>(m_module + m_current_function->unwind_info_rva));
+
+	return value_type{ function_begin, function_end, unwind_info };
+}
+
+portable_executable::runtime_functions_iterator_t& portable_executable::runtime_functions_iterator_t::operator++()
+{
+	++m_current_function;
+
+	return *this;
+}
+
+bool portable_executable::runtime_functions_iterator_t::operator==(const runtime_functions_iterator_t& other) const
+{
+	return m_current_function == other.m_current_function;
+}
+
+bool portable_executable::runtime_functions_iterator_t::operator!=(const runtime_functions_iterator_t& other) const
+{
+	return m_current_function != other.m_current_function;
+}

--- a/portable_executable/portable_executable/exception_directory.hpp
+++ b/portable_executable/portable_executable/exception_directory.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace portable_executable
+{
+    class unwind_code_iterator_t;
+
+    struct unwind_code_t
+    {
+        std::uint8_t offset;
+        std::uint8_t code : 4;
+        std::uint8_t info : 4;
+    };
+
+    struct unwind_info_t
+    {
+        std::uint8_t version : 3;
+        std::uint8_t flags : 5;
+        std::uint8_t size_of_prolog;
+        std::uint8_t unwind_code_count;
+        std::uint8_t frame_register : 4;
+        std::uint8_t frame_offset : 4;
+        unwind_code_t codes[1];
+
+        [[nodiscard]] unwind_code_iterator_t begin() const;
+        [[nodiscard]] unwind_code_iterator_t end() const;
+    };
+
+    struct runtime_function_t
+    {
+        std::uint32_t begin_address;
+        std::uint32_t end_address;
+        std::uint32_t unwind_info_rva;
+    };
+
+    struct runtime_function_descriptor_t
+    {
+        std::uint8_t* function_begin;
+        std::uint8_t* function_end;
+
+        unwind_info_t* unwind_info;
+    };
+
+    class unwind_code_iterator_t
+    {
+        const unwind_code_t* m_current_code = nullptr;
+
+    public:
+        unwind_code_iterator_t() = default;
+
+        unwind_code_iterator_t(const unwind_code_t* unwind_code) :
+            m_current_code(unwind_code)
+        {
+            
+        }
+
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = unwind_code_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+        value_type operator*() const;
+
+        unwind_code_iterator_t& operator++();
+
+        bool operator==(const unwind_code_iterator_t& other) const;
+        bool operator!=(const unwind_code_iterator_t& other) const;
+    };
+
+    class runtime_functions_iterator_t
+    {
+        const std::uint8_t* m_module = nullptr;
+        const runtime_function_t* m_current_function = nullptr;
+
+    public:
+        runtime_functions_iterator_t() = default;
+
+        runtime_functions_iterator_t(const std::uint8_t* const module, const runtime_function_t* runtime_function) :
+            m_module(module),
+			m_current_function(runtime_function)
+        {
+
+        }
+
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = runtime_function_descriptor_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+        value_type operator*() const;
+
+        runtime_functions_iterator_t& operator++();
+
+        bool operator==(const runtime_functions_iterator_t& other) const;
+        bool operator!=(const runtime_functions_iterator_t& other) const;
+    };
+
+    template <typename T>
+    class runtime_functions_range_t
+    {
+    private:
+        using pointer_type = std::conditional_t<std::is_const_v<T>, const std::uint8_t*, std::uint8_t*>;
+        using runtime_function_type = std::conditional_t<std::is_const_v<T>, const runtime_function_t*, runtime_function_t*>;
+
+        pointer_type m_module = nullptr;
+
+        runtime_function_type m_runtime_functions = nullptr;
+        runtime_function_type m_end_runtime_functions = nullptr;
+
+    public:
+        runtime_functions_range_t() = default;
+
+        runtime_functions_range_t(const pointer_type module, const std::uint32_t exception_directory_rva, const std::uint32_t exception_directory_size) :
+            m_module(module),
+            m_runtime_functions(reinterpret_cast<runtime_function_type>(module + exception_directory_rva)),
+            m_end_runtime_functions(reinterpret_cast<runtime_function_type>(module + exception_directory_rva + exception_directory_size))
+        {
+
+        }
+
+        [[nodiscard]] T begin() const
+        {
+            return { m_module, m_runtime_functions };
+        }
+
+        [[nodiscard]] T end() const
+        {
+            return { m_module, m_end_runtime_functions };
+        }
+    };
+}

--- a/portable_executable/portable_executable/image.hpp
+++ b/portable_executable/portable_executable/image.hpp
@@ -7,10 +7,10 @@
 #include "export_directory.hpp"
 #include "imports_directory.hpp"
 #include "relocations_directory.hpp"
+#include "debug_directory.hpp"
+#include "exception_directory.hpp"
 
 #include <vector>
-
-#include "debug_directory.hpp"
 
 namespace portable_executable
 {
@@ -228,6 +228,34 @@ namespace portable_executable
 			const std::uint32_t entries = data_directory.size / sizeof(debug_directory_t);
 
 			return { module, data_directory.virtual_address, entries };
+		}
+
+		[[nodiscard]] runtime_functions_range_t<runtime_functions_iterator_t> runtime_functions()
+		{
+			data_directory_t data_directory = this->nt_headers()->optional_header.data_directories.exception_directory;
+
+			if (!data_directory.present())
+			{
+				return { };
+			}
+
+			auto module = reinterpret_cast<std::uint8_t*>(this);
+
+			return { module, data_directory.virtual_address, data_directory.size };
+		}
+
+		[[nodiscard]] runtime_functions_range_t<const runtime_functions_iterator_t> runtime_functions() const
+		{
+			data_directory_t data_directory = this->nt_headers()->optional_header.data_directories.exception_directory;
+
+			if (!data_directory.present())
+			{
+				return { };
+			}
+
+			auto module = reinterpret_cast<const std::uint8_t*>(this);
+
+			return { module, data_directory.virtual_address, data_directory.size };
 		}
 
 		section_header_t* find_section(std::string_view name);


### PR DESCRIPTION
### Iterating exceptions/runtime functions
The runtime functions iterator abstracts away boilerplate code and returns the pointer to the function begin, function end, and the unwind info.

The unwind code iterator provides the caller with a raw view of the unwind code. This is accessed via the unwind_info_t structure.

```cpp
for (const auto runtime_function : image->runtime_functions())
{
	const auto virtual_address = static_cast<std::uint32_t>(runtime_function.function_begin - image->as<const std::uint8_t*>());

	std::printf("va: 0x%x -> unwind code count: 0x%x\n", virtual_address, runtime_function.unwind_info->unwind_code_count);

	for (const auto unwind_opcode : *runtime_function.unwind_info)
	{
		std::printf("(unwind code) offset: 0x%x, info: 0x%x\n", unwind_opcode.offset, unwind_opcode.info);
	}
}
```